### PR TITLE
refactor Column and HeaderCard and add new metadata

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,6 +9,7 @@
    :maxdepth: 1
    :caption: Modules
 
+   schema_element
    header
    binary_table
    exceptions

--- a/docs/reference/schema_element.rst
+++ b/docs/reference/schema_element.rst
@@ -1,0 +1,7 @@
+=========================================================
+ Common Schema Elements (``fits_schema.schema_element``)
+=========================================================
+
+.. automodule:: fits_schema.schema_element
+   :members:
+   :show-inheritance:

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -6,7 +6,8 @@ https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
 """
 
 import logging
-from abc import ABCMeta, abstractmethod
+import re
+from abc import ABCMeta
 from dataclasses import dataclass
 
 import astropy.units as u
@@ -91,11 +92,21 @@ class Column(SchemaElement, metaclass=ABCMeta):
             # simple column by default
             if self.ndim is None:
                 self.ndim = 0
+        if self.name:
+            self._check_name()
 
     def _check_name(self):
-        """Ensure column name follows FITS conventions."""
-        # allow anything?
-        pass
+        """Ensure column name follows FITS conventions.
+
+        The FITS standard recommends only upper and lower-case letters and
+        spaces, digits, and underscores
+        """
+        if self.name is not None:
+            if not re.fullmatch("[a-zA-Z0-9_]+", self.name):
+                raise ValueError(
+                    f"The column named '{self.name}' should contain only letters, "
+                    "numbers, and underscores."
+                )
 
     def __get__(self, instance, owner=None):
         """Get data."""

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -9,6 +9,7 @@ import logging
 import re
 from abc import ABCMeta
 from dataclasses import dataclass
+from warnings import warn
 
 import astropy.units as u
 import numpy as np
@@ -103,8 +104,8 @@ class Column(SchemaElement, metaclass=ABCMeta):
         """
         if self.name is not None:
             if not re.fullmatch("[a-zA-Z0-9_]+", self.name):
-                raise ValueError(
-                    f"The column named '{self.name}' should contain only letters, "
+                warn(
+                    f"The column named '{self.name}' is recommended to contain only letters, "
                     "numbers, and underscores."
                 )
 

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -61,24 +61,7 @@ class BinaryTableHeader(HeaderSchema):
 
 @dataclass
 class Column(SchemaElement, metaclass=ABCMeta):
-    """A binary table column descriptor.
-
-    Attributes
-    ----------
-    unit: astropy.units.Unit
-        unit of the column
-    strict_unit: bool
-        If True, the unit must match exactly, not only be convertible.
-    required: bool
-        If this column is required (True) or optional (False)
-    name: str
-        Use to specify a different column name than the class attribute name.
-    ndim: int
-        Dimensionality of a single row, numbers have ndim=0.
-        The resulting data column has ``ndim_col = ndim + 1``
-    shape: Tuple[int]
-        Shape of a single row.
-    """
+    """A binary table column descriptor."""
 
     #: allow compatible units if False
     strict_unit: bool = False

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -18,6 +18,7 @@ from astropy.table import Table
 
 from .exceptions import (
     RequiredMissing,
+    SchemaError,
     WrongDims,
     WrongShape,
     WrongType,
@@ -86,7 +87,7 @@ class Column(SchemaElement, metaclass=ABCMeta):
             if self.ndim is None:
                 self.ndim = len(self.shape)
             elif self.ndim != len(self.shape):
-                raise ValueError(
+                raise SchemaError(
                     f"Shape={self.shape} and ndim={self.ndim} do not match"
                 )
         else:
@@ -107,7 +108,7 @@ class Column(SchemaElement, metaclass=ABCMeta):
                 warn(
                     f"The column named '{self.name}' is recommended to contain only letters, "
                     "numbers, and underscores.",
-                    UserWarning,
+                    SchemaError,
                 )
 
     def __get__(self, instance, owner=None):

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -106,7 +106,8 @@ class Column(SchemaElement, metaclass=ABCMeta):
             if not re.fullmatch("[a-zA-Z0-9_]+", self.name):
                 warn(
                     f"The column named '{self.name}' is recommended to contain only letters, "
-                    "numbers, and underscores."
+                    "numbers, and underscores.",
+                    UserWarning,
                 )
 
     def __get__(self, instance, owner=None):

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -120,11 +120,6 @@ class Column(SchemaElement, metaclass=ABCMeta):
         if self.name in instance.__data__:
             del instance.__data__[self.name]
 
-    @property
-    @abstractmethod
-    def dtype():
-        """Equivalent numpy dtype."""
-
     def validate_data(self, data, onerror="raise"):
         """Validate the data of this column in table."""
         if data is None:

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -84,7 +84,9 @@ class Column(SchemaElement, metaclass=ABCMeta):
             if self.ndim is None:
                 self.ndim = len(self.shape)
             elif self.ndim != len(self.shape):
-                raise ValueError(f"Shape={shape} and ndim={ndim} do not match")
+                raise ValueError(
+                    f"Shape={self.shape} and ndim={self.ndim} do not match"
+                )
         else:
             # simple column by default
             if self.ndim is None:

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -120,12 +120,6 @@ class Column(SchemaElement, metaclass=ABCMeta):
         """Set data."""
         instance.__data__[self.name] = value
 
-    def __set_name__(self, owner, name):
-        """Rename variable (protocol)."""
-        # respect user override for names that are not valid identifiers
-        if self.name is None:
-            self.name = name
-
     def __delete__(self, instance):
         """Clear data of this column."""
         if self.name in instance.__data__:

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -5,13 +5,11 @@ See section 7.3 of the FITS standard:
 https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
 """
 
-from dataclasses import dataclass
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Type
+from dataclasses import dataclass
 
 import astropy.units as u
-from astropy.units.decorators import NoneType
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
@@ -24,8 +22,8 @@ from .exceptions import (
     WrongUnit,
 )
 from .header import HeaderCard, HeaderSchema
-from .utils import log_or_raise
 from .schema_element import SchemaElement
+from .utils import log_or_raise
 
 __all__ = [
     "BinaryTableHeader",
@@ -59,6 +57,7 @@ class BinaryTableHeader(HeaderSchema):
     TFIELDS = HeaderCard(type_=int, position=7)
     EXTNAME = HeaderCard(required=False, type_=str)
 
+
 @dataclass
 class Column(SchemaElement, metaclass=ABCMeta):
     """A binary table column descriptor."""
@@ -70,10 +69,10 @@ class Column(SchemaElement, metaclass=ABCMeta):
     ndim: int | None = None
 
     #: specify exact shape (length of each dimension)
-    shape: Tuple[int] | None = None
+    shape: tuple[int] | None = None
 
     # the data type of the column
-    dtype: Type = None
+    dtype: type = None
 
     def __post_init__(self):
         """Check the schema."""
@@ -95,7 +94,6 @@ class Column(SchemaElement, metaclass=ABCMeta):
         """Ensure column name follows FITS conventions."""
         # allow anything?
         pass
-
 
     def __get__(self, instance, owner=None):
         """Get data."""
@@ -284,80 +282,90 @@ class BinaryTable(metaclass=BinaryTableMeta):
             if k in table.columns:
                 col.validate_data(table[k], onerror=onerror)
 
+
 @dataclass
 class Bool(Column):
     """A Boolean binary table column."""
 
     tform_code = "L"
-    dtype : Type = bool
+    dtype: type = bool
+
 
 @dataclass
 class BitField(Column):
     """Bitfield binary table column."""
 
     tform_code = "X"
-    dtype : Type = bool
+    dtype: type = bool
 
 
 @dataclass
 class Byte(Column):
     """Byte binary table column."""
 
-    tform_code : str = "B"
-    dtype : Type = np.uint8
+    tform_code: str = "B"
+    dtype: type = np.uint8
+
 
 @dataclass
 class Int16(Column):
     """16 Bit signed integer binary table column."""
 
-    tform_code : str = "I"
-    dtype : Type = np.int16
+    tform_code: str = "I"
+    dtype: type = np.int16
+
 
 @dataclass
 class Int32(Column):
     """32 Bit signed integer binary table column."""
 
-    tform_code : str = "J"
-    dtype : Type = np.int32
+    tform_code: str = "J"
+    dtype: type = np.int32
+
 
 @dataclass
 class Int64(Column):
     """64 Bit signed integer binary table column."""
 
-    tform_code : str = "K"
-    dtype : Type = np.int64
+    tform_code: str = "K"
+    dtype: type = np.int64
+
 
 @dataclass
 class Char(Column):
     """Single byte character binary table column."""
 
-    tform_code : str = "A"
-    dtype : Type = np.dtype("S1")
+    tform_code: str = "A"
+    dtype: type = np.dtype("S1")
+
 
 @dataclass
 class Float(Column):
     """Single precision floating point binary table column."""
 
-    tform_code : str = "E"
-    dtype : Type = np.float32
+    tform_code: str = "E"
+    dtype: type = np.float32
+
 
 @dataclass
 class Double(Column):
     """Single precision floating point binary table column."""
 
-    tform_code : str = "D"
-    dtype : Type = np.float64
+    tform_code: str = "D"
+    dtype: type = np.float64
+
 
 @dataclass
 class ComplexFloat(Column):
     """Single precision complex binary table column."""
 
-    tform_code : str = "C"
-    dtype : Type = np.csingle
+    tform_code: str = "C"
+    dtype: type = np.csingle
+
 
 @dataclass
 class ComplexDouble(Column):
     """Single precision complex binary table column."""
 
-    tform_code : str = "M"
-    dtype : Type = np.cdouble
+    tform_code: str = "M"
+    dtype: type = np.cdouble

--- a/src/fits_schema/exceptions.py
+++ b/src/fits_schema/exceptions.py
@@ -41,5 +41,5 @@ class AdditionalHeaderCard(UserWarning):
     """Issued when a header has a card not mentioned in the schema."""
 
 
-class SchemaError(UserWarning):
+class SchemaError(ValueError):
     """Errors in Schema Definition, not data validation."""

--- a/src/fits_schema/exceptions.py
+++ b/src/fits_schema/exceptions.py
@@ -39,3 +39,7 @@ class WrongValue(ValidationError):
 
 class AdditionalHeaderCard(UserWarning):
     """Issued when a header has a card not mentioned in the schema."""
+
+
+class SchemaError(UserWarning):
+    """Errors in Schema Definition, not data validation."""

--- a/src/fits_schema/fits_standard.py
+++ b/src/fits_schema/fits_standard.py
@@ -29,15 +29,15 @@ class FITSStandardHeaders(HeaderSchema):
 
     # see table 22 of https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
     DATE = HeaderCard(type_=str, required=False)
-    DATE_OBS = HeaderCard(keyword="DATE-OBS", type_=str, required=False)
-    DATE_BEG = HeaderCard(keyword="DATE-BEG", type_=str, required=False)
-    DATE_AVG = HeaderCard(keyword="DATE-AVG", type_=str, required=False)
-    DATE_END = HeaderCard(keyword="DATE-END", type_=str, required=False)
+    DATE_OBS = HeaderCard(name="DATE-OBS", type_=str, required=False)
+    DATE_BEG = HeaderCard(name="DATE-BEG", type_=str, required=False)
+    DATE_AVG = HeaderCard(name="DATE-AVG", type_=str, required=False)
+    DATE_END = HeaderCard(name="DATE-END", type_=str, required=False)
 
-    MJD_OBS = HeaderCard(keyword="MJD-OBS", type_=float, required=False)
-    MJD_BEG = HeaderCard(keyword="MJD-BEG", type_=float, required=False)
-    MJD_AVG = HeaderCard(keyword="MJD-AVG", type_=float, required=False)
-    MJD_END = HeaderCard(keyword="MJD-END", type_=float, required=False)
+    MJD_OBS = HeaderCard(name="MJD-OBS", type_=float, required=False)
+    MJD_BEG = HeaderCard(name="MJD-BEG", type_=float, required=False)
+    MJD_AVG = HeaderCard(name="MJD-AVG", type_=float, required=False)
+    MJD_END = HeaderCard(name="MJD-END", type_=float, required=False)
 
     # time definition
     MJDREF = HeaderCard(type_=float, required=False)

--- a/src/fits_schema/header.py
+++ b/src/fits_schema/header.py
@@ -69,7 +69,8 @@ class HeaderCard(SchemaElement):
             if vals is not None:
                 if any(not isinstance(v, self.type_) for v in vals):
                     raise TypeError(
-                        f"`values` must be of type `type_`({self.type_}) or None"
+                        f"The type of `allowed_values` ({self.allowed_values}) "
+                        f"and `type_` ({self.type_}) do not agree."
                     )
         else:
             # if only value is supplied, deduce type from value

--- a/src/fits_schema/header.py
+++ b/src/fits_schema/header.py
@@ -38,36 +38,7 @@ IGNORE = TABLE_KEYWORDS
 
 @dataclass
 class HeaderCard(SchemaElement):
-    """
-    Schema for the entry of a FITS header.
-
-    Attributes
-    ----------
-    name: str
-        override the keyword given as the class member name,
-        useful to define keywords containing hyphens or starting with numbers
-    description: str
-        Description of this header.
-    required: bool
-        If this card is required
-    allowed_values: instance of any in ``HEADER_ALLOWED_TYPES`` or iterable of that
-        If specified, card must have one of these values
-    position: int or None
-        if not None, the card must be at this position in the header,
-        starting with the first card at 0
-    type_: one or a tuple of the types in ``HEADER_ALLOWED_TYPES``
-    empty: True, False or None
-        If True, value must be empty, if False must not be empty,
-        if None, no check if a value is present is performed
-    case_insensitive: True
-        match str values case insensitively
-    reference: str | None
-        Citation for the origin of this keyword
-    examples: list[str] | None
-        List of example values, to use in documentation
-    ivoa_key: str
-        Relevant keyword in the IVOA standards, including the standard, e.g. ObsCore.institute
-    """
+    """Schema for the entry of a FITS header."""
 
     allowed_values: Iterable | None = None
     position: int | None = None

--- a/src/fits_schema/header.py
+++ b/src/fits_schema/header.py
@@ -45,6 +45,7 @@ class HeaderCard(SchemaElement):
     case_insensitive: bool = True
 
     def __post_init__(self):
+        """Validate the header schema."""
         # super().__post_init__()
 
         vals = self.allowed_values

--- a/src/fits_schema/header.py
+++ b/src/fits_schema/header.py
@@ -78,6 +78,9 @@ class HeaderCard(SchemaElement):
 
         self.allowed_values = vals
 
+        if self.name:
+            self._check_name()
+
     def _check_name(self):
         """Ensure card name follows FITS conventions."""
         if self.name is not None:

--- a/src/fits_schema/header.py
+++ b/src/fits_schema/header.py
@@ -5,15 +5,13 @@ See section 4 of the FITS Standard:
 https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
 """
 
-from dataclasses import dataclass
 import logging
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Self, Iterable, Tuple, Type
+from typing import Self
 
-
-from astropy import units as u
 from astropy.io import fits
 
 from .exceptions import (
@@ -23,9 +21,8 @@ from .exceptions import (
     WrongType,
     WrongValue,
 )
-from .utils import log_or_raise
-
 from .schema_element import SchemaElement
+from .utils import log_or_raise
 
 __all__ = ["HeaderSchema", "HeaderCard"]
 
@@ -36,19 +33,19 @@ HEADER_ALLOWED_TYPES = (str, bool, int, float, complex, date, datetime)
 TABLE_KEYWORDS = {"TTYPE", "TUNIT", "TFORM", "TSCAL", "TZERO", "TDISP", "TDIM"}
 IGNORE = TABLE_KEYWORDS
 
+
 @dataclass
 class HeaderCard(SchemaElement):
     """Schema for the entry of a FITS header."""
 
     allowed_values: Iterable | None = None
     position: int | None = None
-    type_: Type | Tuple[Type] | None = None
+    type_: type | tuple[type] | None = None
     empty: bool | None = None
     case_insensitive: bool = True
 
-
     def __post_init__(self):
-        #super().__post_init__()
+        # super().__post_init__()
 
         vals = self.allowed_values
         if vals is not None:
@@ -80,7 +77,6 @@ class HeaderCard(SchemaElement):
 
         self.allowed_values = vals
 
-
     def _check_name(self):
         """Ensure card name follows FITS conventions."""
         if self.name is not None:
@@ -92,7 +88,6 @@ class HeaderCard(SchemaElement):
                     "FITS header keywords must only contain"
                     " ascii uppercase, digit, _ or -"
                 )
-
 
     def validate(self, card, pos, onerror="raise"):
         """Validate an astropy.io.fits.card.Card."""

--- a/src/fits_schema/header.py
+++ b/src/fits_schema/header.py
@@ -17,6 +17,7 @@ from astropy.io import fits
 from .exceptions import (
     AdditionalHeaderCard,
     RequiredMissing,
+    SchemaError,
     WrongPosition,
     WrongType,
     WrongValue,
@@ -59,7 +60,7 @@ class HeaderCard(SchemaElement):
                 vals = set(v.upper() if isinstance(v, str) else v for v in vals)
 
             if not all(isinstance(v, HEADER_ALLOWED_TYPES) for v in vals):
-                raise ValueError(f"Values must be instances of {HEADER_ALLOWED_TYPES}")
+                raise SchemaError(f"Values must be instances of {HEADER_ALLOWED_TYPES}")
 
         if self.type_ is not None:
             if isinstance(self.type_, Iterable):
@@ -68,7 +69,7 @@ class HeaderCard(SchemaElement):
             # check that value and type match if both supplied
             if vals is not None:
                 if any(not isinstance(v, self.type_) for v in vals):
-                    raise TypeError(
+                    raise SchemaError(
                         f"The type of `allowed_values` ({self.allowed_values}) "
                         f"and `type_` ({self.type_}) do not agree."
                     )
@@ -86,10 +87,12 @@ class HeaderCard(SchemaElement):
         """Ensure card name follows FITS conventions."""
         if self.name is not None:
             if len(self.name) > 8:
-                raise ValueError("FITS header keywords must be 8 characters or shorter")
+                raise SchemaError(
+                    "FITS header keywords must be 8 characters or shorter"
+                )
 
             if not re.match(r"^[A-Z0-9\-_]{1,8}$", self.name):
-                raise ValueError(
+                raise SchemaError(
                     "FITS header keywords must only contain"
                     " ascii uppercase, digit, _ or -"
                 )

--- a/src/fits_schema/primary.py
+++ b/src/fits_schema/primary.py
@@ -14,4 +14,4 @@ class PrimaryHeader(HeaderSchema):
     INSTRUME = HeaderCard(type_=str, required=False)
     OBSERVER = HeaderCard(type_=str, required=False)
     OBJECT = HeaderCard(type_=str, required=False)
-    DATE_OBS = HeaderCard(keyword="DATE-OBS", type_=str, required=False)
+    DATE_OBS = HeaderCard(name="DATE-OBS", type_=str, required=False)

--- a/src/fits_schema/schema_element.py
+++ b/src/fits_schema/schema_element.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""Defines common schema metadata inherited by Column and HeaderCard."""
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from astropy.units import Unit
+from astropy.io.votable.ucd import check_ucd
+
+# collects all references used, useful for generating a citation list.
+_REFERENCE_SET = set()
+
+
+@dataclass
+class SchemaElement(metaclass=ABCMeta):
+    """Base for Schema elements defining common metadata keys."""
+
+    #: name to use if not the attribute name, useful in case the column or
+    #: header has a non-python-allowed name, i.e. with a ``-`` or starting with a
+    #: number
+    name: str | None = None
+
+    #: human-readable description
+    description: str = ""
+
+    #: if this item is optional, set to false
+    required: bool = True
+
+    #: the unit that should be checked for compatibility
+    unit: Unit | None = None
+
+    #: list of examples, for documentation
+    examples: list[str] | None = None
+
+    #: Citation for the origin of this attribute.
+    reference: str | None = None
+
+    #: IVOA uniform content descriptor string
+    ucd: str | None = None
+
+    def __post_init__(self):
+        """check that the metadata keywords are as expected"""
+
+        if not isinstance(self.description, str):
+            raise ValueError("description should be a string")
+
+        if self.unit:
+            self.unit = Unit(self.unit)
+
+        if self.examples and not isinstance(self.examples, list):
+            raise ValueError("examples should be a list of strings")
+
+        if self.examples is None:
+            self.examples = []
+
+        if self.ucd:
+            if check_ucd(self.ucd, check_controlled_vocabulary=True) is False:
+                raise ValueError(f"UCD '{self.ucd}' is not valid")
+
+        if self.reference:
+            if not isinstance(self.reference, str):
+                raise ValueError("Reference should be a string")
+            else:
+                _REFERENCE_SET.add(self.reference)
+
+    def __set_name__(self, owner, name):
+        """Rename self.name to the class variable if it is not specified."""
+        if self.name is None:
+            self.name = name
+        self._check_name()
+
+    @abstractmethod
+    def _check_name(self):
+        """Check if the name is valid."""
+        print("CHECK NAME BASE")
+        pass

--- a/src/fits_schema/schema_element.py
+++ b/src/fits_schema/schema_element.py
@@ -72,5 +72,4 @@ class SchemaElement(metaclass=ABCMeta):
     @abstractmethod
     def _check_name(self):
         """Check if the name is valid."""
-        print("CHECK NAME BASE")
         pass

--- a/src/fits_schema/schema_element.py
+++ b/src/fits_schema/schema_element.py
@@ -4,8 +4,9 @@
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from astropy.units import Unit
+
 from astropy.io.votable.ucd import check_ucd
+from astropy.units import Unit
 
 # collects all references used, useful for generating a citation list.
 _REFERENCE_SET = set()
@@ -40,8 +41,7 @@ class SchemaElement(metaclass=ABCMeta):
     ucd: str | None = None
 
     def __post_init__(self):
-        """check that the metadata keywords are as expected"""
-
+        """Check that the metadata keywords are as expected"""
         if not isinstance(self.description, str):
             raise ValueError("description should be a string")
 

--- a/src/fits_schema/schema_element.py
+++ b/src/fits_schema/schema_element.py
@@ -26,7 +26,8 @@ class SchemaElement(metaclass=ABCMeta):
     #: if this item is optional, set to false
     required: bool = True
 
-    #: the unit that should be checked for compatibility
+    #: The unit associated with the element. For Columns, this will be verified if set,
+    #: for HeaderCards, it is only for documentation purposes.
     unit: Unit | None = None
 
     #: list of examples, for documentation

--- a/src/fits_schema/schema_element.py
+++ b/src/fits_schema/schema_element.py
@@ -40,6 +40,10 @@ class SchemaElement(metaclass=ABCMeta):
     #: IVOA uniform content descriptor string
     ucd: str | None = None
 
+    #: If this element is associated with an IVOA data model, provide the
+    #: ``ModelName.keyword``, for example ``ObsCore.obs_publisher_did``
+    ivoa_name: str | None = None
+
     def __post_init__(self):
         """Validate the schema keywords."""
         if not isinstance(self.description, str):

--- a/src/fits_schema/schema_element.py
+++ b/src/fits_schema/schema_element.py
@@ -41,7 +41,7 @@ class SchemaElement(metaclass=ABCMeta):
     ucd: str | None = None
 
     def __post_init__(self):
-        """Check that the metadata keywords are as expected"""
+        """Validate the schema keywords."""
         if not isinstance(self.description, str):
             raise ValueError("description should be a string")
 

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -60,19 +60,19 @@ def test_repr():
 
     assert (
         repr(TestTable.test)
-        == "Double(name='test', description='', required=True, unit=None, examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
+        == "Double(name='test', description='', required=True, unit=None, examples=[], reference=None, ucd=None, ivoa_name=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
     )
 
     TestTable.test.unit = u.m
     assert (
         repr(TestTable.test)
-        == "Double(name='test', description='', required=True, unit=Unit(\"m\"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
+        == "Double(name='test', description='', required=True, unit=Unit(\"m\"), examples=[], reference=None, ucd=None, ivoa_name=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
     )
 
     TestTable.test.unit = u.m**-2
     assert (
         repr(TestTable.test)
-        == "Double(name='test', description='', required=True, unit=Unit(\"1 / m2\"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
+        == "Double(name='test', description='', required=True, unit=Unit(\"1 / m2\"), examples=[], reference=None, ucd=None, ivoa_name=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
     )
 
 
@@ -314,8 +314,8 @@ def test_column_name():
 
     # check that adding other characters fails:
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         Int32(name="this-should-fail")
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         Int32(name="Has Spaces")

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -307,15 +307,15 @@ def test_header():
 
 
 def test_column_name():
-    from fits_schema import Int32, BinaryTable
+    from fits_schema import Int32
 
     # ensure that upper, lower, underscore, and numbers match
-    col = Int32(name="UPPERLower_Thing0123456")
+    Int32(name="UPPERLower_Thing0123456")
 
     # check that adding other characters fails:
 
     with pytest.raises(ValueError):
-        col = Int32(name="this-should-fail")
+        Int32(name="this-should-fail")
 
     with pytest.raises(ValueError):
-        col = Int32(name="Has Spaces")
+        Int32(name="Has Spaces")

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -58,13 +58,13 @@ def test_repr():
     class TestTable(BinaryTable):
         test = Double()
 
-    assert repr(TestTable.test) == "Double(name='test', required=True, unit=None)"
+    assert repr(TestTable.test) == "Double(name='test', description='', required=True, unit=None, examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
 
     TestTable.test.unit = u.m
-    assert repr(TestTable.test) == "Double(name='test', required=True, unit='m')"
+    assert repr(TestTable.test) == 'Double(name=\'test\', description=\'\', required=True, unit=Unit("m"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class \'numpy.float64\'>, tform_code=\'D\')'
 
     TestTable.test.unit = u.m**-2
-    assert repr(TestTable.test) == "Double(name='test', required=True, unit='m-2')"
+    assert repr(TestTable.test) == 'Double(name=\'test\', description=\'\', required=True, unit=Unit("1 / m2"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class \'numpy.float64\'>, tform_code=\'D\')'
 
 
 def test_access():

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -58,13 +58,22 @@ def test_repr():
     class TestTable(BinaryTable):
         test = Double()
 
-    assert repr(TestTable.test) == "Double(name='test', description='', required=True, unit=None, examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
+    assert (
+        repr(TestTable.test)
+        == "Double(name='test', description='', required=True, unit=None, examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
+    )
 
     TestTable.test.unit = u.m
-    assert repr(TestTable.test) == 'Double(name=\'test\', description=\'\', required=True, unit=Unit("m"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class \'numpy.float64\'>, tform_code=\'D\')'
+    assert (
+        repr(TestTable.test)
+        == "Double(name='test', description='', required=True, unit=Unit(\"m\"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
+    )
 
     TestTable.test.unit = u.m**-2
-    assert repr(TestTable.test) == 'Double(name=\'test\', description=\'\', required=True, unit=Unit("1 / m2"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class \'numpy.float64\'>, tform_code=\'D\')'
+    assert (
+        repr(TestTable.test)
+        == "Double(name='test', description='', required=True, unit=Unit(\"1 / m2\"), examples=[], reference=None, ucd=None, strict_unit=False, ndim=0, shape=None, dtype=<class 'numpy.float64'>, tform_code='D')"
+    )
 
 
 def test_access():

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -304,3 +304,18 @@ def test_header():
     t.meta["TEST"] = "hello"
     hdu = fits.BinTableHDU(t)
     TestTable.validate_hdu(hdu)
+
+
+def test_column_name():
+    from fits_schema import Int32, BinaryTable
+
+    # ensure that upper, lower, underscore, and numbers match
+    col = Int32(name="UPPERLower_Thing0123456")
+
+    # check that adding other characters fails:
+
+    with pytest.raises(ValueError):
+        col = Int32(name="this-should-fail")
+
+    with pytest.raises(ValueError):
+        col = Int32(name="Has Spaces")

--- a/src/fits_schema/tests/test_header.py
+++ b/src/fits_schema/tests/test_header.py
@@ -23,7 +23,7 @@ def test_length():
             lowercas = HeaderCard()
 
     class DateHeader(HeaderSchema):
-        DATE_OBS = HeaderCard(keyword="DATE-OBS")
+        DATE_OBS = HeaderCard(name="DATE-OBS")
 
     assert "DATE-OBS" in DateHeader.__cards__
 
@@ -140,8 +140,8 @@ def test_inheritance():
         BAR = HeaderCard(type_=int)
 
     assert set(Header.__cards__) == set(BaseHeader.__cards__)
-    assert BaseHeader.BAR.type is str
-    assert Header.BAR.type is int
+    assert BaseHeader.BAR.type_ is str
+    assert Header.BAR.type_ is int
 
 
 def test_invalid_arguments():

--- a/src/fits_schema/tests/test_header.py
+++ b/src/fits_schema/tests/test_header.py
@@ -3,6 +3,7 @@ from astropy.io import fits
 
 from fits_schema.exceptions import (
     RequiredMissing,
+    SchemaError,
     WrongPosition,
     WrongType,
     WrongValue,
@@ -12,12 +13,12 @@ from fits_schema.exceptions import (
 def test_length():
     from fits_schema.header import HeaderCard, HeaderSchema
 
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises((SchemaError, RuntimeError)):
 
         class LengthHeader(HeaderSchema):
             MORE_THAN_8 = HeaderCard()
 
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises((SchemaError, RuntimeError)):
 
         class LowerHeader(HeaderSchema):
             lowercas = HeaderCard()
@@ -147,10 +148,10 @@ def test_inheritance():
 def test_invalid_arguments():
     from fits_schema.header import HeaderCard
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SchemaError):
         HeaderCard(allowed_values=[(1, 2, 3)])
 
-    with pytest.raises(TypeError):
+    with pytest.raises(SchemaError):
         # allowed values does not match allowed type
         HeaderCard(type_=str, allowed_values=1)
 


### PR DESCRIPTION
Fixes #11 

This is a somewhat large refactoring, but seems so far to not break anything.  

- makes both `Column` and HeaderCard into `dataclasses`, simplifying a bit their init and reprs
- make them both inherit from a parent `SchemaElement` class, containing the common metadata
- add new common metadata to the parent class (description, ucd, reference, examples, unit: see #11 )
- put all schema validation into __post__init__()