### PR TITLE
Make it work with actual table data

### DIFF
--- a/src/fits_schema/__init__.py
+++ b/src/fits_schema/__init__.py
@@ -14,7 +14,7 @@ from .binary_table import (
     Int64,
     Table,
 )
-from .header import HeaderCard, HeaderSchema
+from .header import Header, HeaderCard
 from .version import __version__
 
 __all__ = [
@@ -23,7 +23,7 @@ __all__ = [
     "BinaryTable",
     "BinaryTableHeader",
     "HeaderCard",
-    "HeaderSchema",
+    "Header",
     "Int16",
     "Int32",
     "Int64",

--- a/src/fits_schema/fits_standard.py
+++ b/src/fits_schema/fits_standard.py
@@ -2,12 +2,12 @@
 
 """Definitions from the FITS standard, for schema validation."""
 
-from .header import HeaderCard, HeaderSchema
+from .header import Header, HeaderCard
 
 __all__ = ["FITSStandardHeaders"]
 
 
-class FITSStandardHeaders(HeaderSchema):
+class FITSStandardHeaders(Header):
     """FITS standard headers.
 
     Optional Headers defined by the `FITS Standard v4.0

--- a/src/fits_schema/header.py
+++ b/src/fits_schema/header.py
@@ -22,7 +22,7 @@ from .exceptions import (
 )
 from .utils import log_or_raise
 
-__all__ = ["HeaderSchema", "HeaderCard"]
+__all__ = ["Header", "HeaderCard"]
 
 log = logging.getLogger(__name__)
 
@@ -122,6 +122,19 @@ class HeaderCard:
                 )
             self.keyword = name
 
+    def __get__(self, instance: "None | Header", owner: "None | HeaderMeta" = None):
+        """Delegate to the actual fits header for getting value."""
+        # accessed as class attribute
+        if instance is None:
+            return self
+        return instance._header[self.keyword]
+
+    def __set__(self, instance: "Header", value):
+        """Delegate to the actual fits header for setting value."""
+        # TODO: need to validate here before setting
+        # but current validate only works after value has been set
+        instance._header[self.keyword] = value
+
     def validate(self, card, pos, onerror="raise"):
         """Validate an astropy.io.fits.card.Card."""
         valid = True
@@ -169,16 +182,16 @@ class HeaderCard:
         return valid
 
 
-class HeaderSchemaMeta(type):
+class HeaderMeta(type):
     """Metaclass for HeaderSchema."""
 
     def __new__(cls, name, bases, dct):
         """Instantiate and check a HeaderSchema."""
         dct["__cards__"] = {}
-        dct["__slots__"] = tuple()
+        dct["__slots__"] = ("_header",)
 
         for base in reversed(bases):
-            if issubclass(base, HeaderSchema):
+            if issubclass(base, Header):
                 dct["__cards__"].update(base.__cards__)
 
         for k, v in dct.items():
@@ -190,7 +203,7 @@ class HeaderSchemaMeta(type):
         return new_cls
 
 
-class HeaderSchema(metaclass=HeaderSchemaMeta):
+class Header(metaclass=HeaderMeta):
     """
     Schema definition for the header of a FITS HDU.
 
@@ -208,15 +221,18 @@ class HeaderSchema(metaclass=HeaderSchemaMeta):
     ...     BAR = HeaderCard(required=True, type_=str)  # doctest: +SKIP
     """
 
+    def __init__(self, header):
+        self._header = header
+
     @classmethod
     def _header_schemas(cls) -> list[Self]:
-        """Return a list of HeaderSchema parents."""
+        """Return a list of Header parents."""
         return list(
             reversed(
                 [
                     cls,
                 ]
-                + [base for base in cls.__bases__ if issubclass(base, HeaderSchema)]
+                + [base for base in cls.__bases__ if issubclass(base, Header)]
             )
         )
 

--- a/src/fits_schema/primary.py
+++ b/src/fits_schema/primary.py
@@ -1,9 +1,9 @@
 """Primary Header Schema."""
 
-from .header import HeaderCard, HeaderSchema
+from .header import Header, HeaderCard
 
 
-class PrimaryHeader(HeaderSchema):
+class PrimaryHeader(Header):
     """Primary Header Schema."""
 
     SIMPLE = HeaderCard(allowed_values=[True], position=0)

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -2,7 +2,7 @@ import astropy.units as u
 import numpy as np
 import pytest
 from astropy.io import fits
-from astropy.table import Table
+from astropy.table import Column, Table
 
 from fits_schema.exceptions import (
     RequiredMissing,
@@ -20,36 +20,33 @@ def test_unit():
         test = Double(unit=u.m)
 
     # allow no units
-    table = TestTable(test=[1, 2, 3])
+    table = TestTable(Table({"test": [1, 2, 3]}))
     table.validate_data()
     assert (table.test == u.Quantity([1, 2, 3], u.m)).all()
 
     # convertible unit
-    table = TestTable(test=[1, 2, 3] * u.cm)
+    table = TestTable(Table(dict(test=[1, 2, 3] * u.cm)))
     table.validate_data()
 
-    table = TestTable(test=5 * u.deg)
     with pytest.raises(WrongUnit):
-        table.validate_data()
+        table = TestTable(Table(dict(test=[5] * u.deg)))
 
     # validate no unit is enforced:
     class TestTable(BinaryTable):
         test = Double(unit=u.dimensionless_unscaled)
 
-    table = TestTable(test=[1, 2, 3])
+    table = TestTable(Table(dict(test=[1, 2, 3])))
     table.validate_data()
 
-    table = TestTable(test=[1, 2, 3] * u.deg)
     with pytest.raises(WrongUnit):
-        table.validate_data()
+        table = TestTable(Table(dict(test=[1, 2, 3] * u.deg)))
 
     # test strict_unit
     class TestTable(BinaryTable):
         test = Double(unit=u.m, strict_unit=True)
 
-    table = TestTable(test=[1, 2, 3] * u.cm)
     with pytest.raises(WrongUnit):
-        table.validate_data()
+        table = TestTable(Table(dict(test=[1, 2, 3] * u.cm)))
 
 
 def test_repr():
@@ -73,7 +70,7 @@ def test_access():
     class TestTable(BinaryTable):
         test = Double(required=False)
 
-    t = TestTable()
+    t = TestTable(Table({}))
     assert t.test is None
     t.test = [5.0]
     assert t.test[0] == 5.0
@@ -96,19 +93,16 @@ def test_shape():
         test = Double(shape=(10,))
 
     # single number, wrong number of dimensions
-    table = TestTable(test=3.14)
     with pytest.raises(WrongDims):
-        table.validate_data()
+        TestTable(Table({"test": [3.14]}))
 
     # three numbers per row, should be ten
-    table = TestTable(test=[[1, 2, 3]])
     with pytest.raises(WrongShape):
-        table.validate_data()
+        TestTable(Table({"test": [[1, 2, 3]]}))
 
     # this should work
     rng = np.random.default_rng(1337)
-    table = TestTable(test=[np.arange(10), rng.normal(size=10)])
-    table.validate_data()
+    TestTable(Table({"test": [np.arange(10), rng.normal(size=10)]}))
 
 
 def test_ndim():
@@ -118,40 +112,43 @@ def test_ndim():
         test = Double(ndim=2)
 
     # single numbers
-    table = TestTable(test=[1, 2, 3])
     with pytest.raises(WrongDims):
-        table.validate_data()
+        TestTable(Table({"test": [1, 2, 3]}))
 
     # 1d
-    table = TestTable(
-        test=[
-            [1, 2, 3],
-            [4, 5, 6],
-        ]
-    )
     with pytest.raises(WrongDims):
-        table.validate_data()
+        TestTable(
+            Table(
+                dict(
+                    test=[
+                        [1, 2, 3],
+                        [4, 5, 6],
+                    ]
+                )
+            )
+        )
 
     # each row is 2d, fits
-    table = TestTable(
-        test=[
-            np.random.default_rng().normal(size=(5, 3)),
-            np.random.default_rng().normal(size=(5, 3)),
-        ]
+    TestTable(
+        Table(
+            dict(
+                test=[
+                    np.random.default_rng().normal(size=(5, 3)),
+                    np.random.default_rng().normal(size=(5, 3)),
+                ]
+            )
+        )
     )
-    table.validate_data()
 
     # 3d not
-    table = TestTable(test=[np.zeros((2, 2, 2)), np.ones((2, 2, 2))])
     with pytest.raises(WrongDims):
-        table.validate_data()
+        TestTable(Table(dict(test=[np.zeros((2, 2, 2)), np.ones((2, 2, 2))])))
 
     class TestTable(BinaryTable):
         test = Double()
 
     # check a single number is allowed for normal columns
-    table = TestTable(test=5)
-    table.validate_data()
+    TestTable(Table(dict(test=[5])))
 
 
 def test_required():
@@ -160,13 +157,10 @@ def test_required():
     class TestTable(BinaryTable):
         test = Bool(required=True)
 
-    table = TestTable()
-
     with pytest.raises(RequiredMissing):
-        table.validate_data()
+        TestTable(Table({}))
 
-    table.test = [True, False]
-    table.validate_data()
+    TestTable(Table(dict(test=[True, False])))
 
 
 def test_data_types():
@@ -175,7 +169,7 @@ def test_data_types():
     class TestTable(BinaryTable):
         test = Int16(required=False)
 
-    table = TestTable()
+    table = TestTable(Table({}))
 
     # check no data is ok, as column is optional
     assert table.validate_data() is None
@@ -295,3 +289,38 @@ def test_header():
     t.meta["TEST"] = "hello"
     hdu = fits.BinTableHDU(t)
     TestTable.validate_hdu(hdu)
+
+
+@pytest.fixture
+def events_file(tmp_path):
+    energy = [0.1, 0.2, 0.3] * u.TeV
+    event_id = np.arange(len(energy))
+    table = Table({"event_id": event_id, "energy": energy})
+
+    hdu = fits.BinTableHDU(table, name="EVENTS")
+    hdu.header["OBS_ID"] = 1
+
+    hdul = fits.HDUList([fits.PrimaryHDU(), hdu])
+    path = tmp_path / "events.fits.gz"
+    hdul.writeto(path)
+    return path
+
+
+def test_data(events_file):
+    from fits_schema.binary_table import BinaryTable, BinaryTableHeader, Double, Int64
+    from fits_schema.header import HeaderCard
+
+    class EventsTable(BinaryTable):
+        event_id = Int64()
+        energy = Double(unit=u.TeV)
+
+        class __header__(BinaryTableHeader):
+            OBS_ID = HeaderCard(type_=int)
+
+    with fits.open(events_file) as hdul:
+        events = EventsTable(hdul["EVENTS"])
+
+    assert isinstance(events.event_id, Column)
+    assert isinstance(events.energy, Column)
+    assert len(events.event_id) == 3
+    assert events.energy.unit == u.TeV

--- a/src/fits_schema/tests/test_header.py
+++ b/src/fits_schema/tests/test_header.py
@@ -10,19 +10,19 @@ from fits_schema.exceptions import (
 
 
 def test_length():
-    from fits_schema.header import HeaderCard, HeaderSchema
+    from fits_schema.header import Header, HeaderCard
 
     with pytest.raises((ValueError, RuntimeError)):
 
-        class LengthHeader(HeaderSchema):
+        class LengthHeader(Header):
             MORE_THAN_8 = HeaderCard()
 
     with pytest.raises((ValueError, RuntimeError)):
 
-        class LowerHeader(HeaderSchema):
+        class LowerHeader(Header):
             lowercas = HeaderCard()
 
-    class DateHeader(HeaderSchema):
+    class DateHeader(Header):
         DATE_OBS = HeaderCard(keyword="DATE-OBS")
 
     assert "DATE-OBS" in DateHeader.__cards__
@@ -73,11 +73,11 @@ def test_wrong_value():
 
 
 def test_type():
-    from fits_schema.header import HeaderCard, HeaderSchema
+    from fits_schema.header import Header, HeaderCard
 
     h = fits.Header()
 
-    class Header(HeaderSchema):
+    class Header(Header):
         TEST = HeaderCard(type_=str)
 
     h["TEST"] = 5
@@ -87,7 +87,7 @@ def test_type():
     h["TEST"] = "hello"
     Header.validate_header(h)
 
-    class Header(HeaderSchema):
+    class Header(Header):
         TEST = HeaderCard(type_=[str, int])
 
     h["TEST"] = "hello"
@@ -101,11 +101,11 @@ def test_type():
 
 
 def test_empty():
-    from fits_schema.header import HeaderCard, HeaderSchema
+    from fits_schema.header import Header, HeaderCard
 
     h = fits.Header()
 
-    class Header(HeaderSchema):
+    class Header(Header):
         TEST = HeaderCard(empty=True)
 
     h["TEST"] = None
@@ -118,7 +118,7 @@ def test_empty():
     with pytest.raises(WrongValue):
         Header.validate_header(h)
 
-    class Header(HeaderSchema):
+    class Header(Header):
         TEST = HeaderCard(empty=False)
 
     h["TEST"] = None
@@ -130,9 +130,9 @@ def test_empty():
 
 
 def test_inheritance():
-    from fits_schema.header import HeaderCard, HeaderSchema
+    from fits_schema.header import Header, HeaderCard
 
-    class BaseHeader(HeaderSchema):
+    class BaseHeader(Header):
         FOO = HeaderCard()
         BAR = HeaderCard(type_=str)
 
@@ -157,9 +157,9 @@ def test_invalid_arguments():
 
 def test_additional():
     from fits_schema.exceptions import AdditionalHeaderCard
-    from fits_schema.header import HeaderCard, HeaderSchema
+    from fits_schema.header import Header, HeaderCard
 
-    class Header(HeaderSchema):
+    class Header(Header):
         TEST = HeaderCard()
 
     h = fits.Header()
@@ -171,9 +171,9 @@ def test_additional():
 
 
 def test_case():
-    from fits_schema.header import HeaderCard, HeaderSchema
+    from fits_schema.header import Header, HeaderCard
 
-    class Header(HeaderSchema):
+    class Header(Header):
         TEST = HeaderCard(allowed_values={"foo"})
 
     h = fits.Header()
@@ -186,7 +186,7 @@ def test_case():
     h["TEST"] = "FOO"
     Header.validate_header(h)
 
-    class Header(HeaderSchema):
+    class Header(Header):
         TEST = HeaderCard(allowed_values={"foo"}, case_insensitive=False)
 
     h["TEST"] = "Foo"


### PR DESCRIPTION
This goes into the direction of what I mentioned here: https://github.com/VODF/fits_schema/pull/24#issuecomment-2621236134

I.e. making instances of the schema definitions actually useful à la pydantic / dataclasses by storing astropy tables / fits headers in them and making full use of the descriptor protocol. 

