### PR TITLE
Support string columns

### DIFF
--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -195,6 +195,14 @@ class Column(SchemaElement, metaclass=ABCMeta):
                     log=log,
                     onerror=onerror,
                 )
+            if not all(s.isascii() for s in data):
+                log_or_raise(
+                    f"String column {self.name} contains non-ascii characters",
+                    WrongType,
+                    log=log,
+                    onerror=onerror,
+                )
+
         else:
             # For non-strings, the rest of the tests is done on a quantity
             # object with correct dtype, unless the type is str

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -96,6 +96,10 @@ class Column(SchemaElement, metaclass=ABCMeta):
             # simple column by default
             if self.ndim is None:
                 self.ndim = 0
+
+        if (self.dtype == str) and self.unit:
+            raise SchemaError("Units are not compatible with string columns.")
+
         if self.name:
             self._check_name()
 

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -99,8 +99,8 @@ class Column(SchemaElement, metaclass=ABCMeta):
             if self.ndim is None:
                 self.ndim = 0
 
-        if _is_string_dtype(self.dtype) and self.unit:
-            raise SchemaError("Units are not compatible with string columns.")
+        if (_is_string_dtype(self.dtype) or self.dtype is bool) and self.unit:
+            raise SchemaError("Units are not compatible with the type `{self.dtype}`.")
 
         if self.name:
             self._check_name()

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -99,7 +99,7 @@ class Column(SchemaElement, metaclass=ABCMeta):
             if self.ndim is None:
                 self.ndim = 0
 
-        if (self.dtype == str) and self.unit:
+        if _is_string_dtype(self.dtype) and self.unit:
             raise SchemaError("Units are not compatible with string columns.")
 
         if self.name:
@@ -186,7 +186,9 @@ class Column(SchemaElement, metaclass=ABCMeta):
         # includes the length, which we don't want to check, so we have to use
         # `np.dtype.char` to compare:
         if _is_string_dtype(self.dtype):
-            if data.dtype.char != self.dtype.char:
+            # note numpy converts back to U if the file has round-tripped to
+            # FITS, so need to check both
+            if data.dtype.char not in {"S", "U"}:
                 log_or_raise(
                     f"String column {self.name} with `{data.dtype.char}` dtype should be `{self.dtype.char}`",
                     WrongType,

--- a/src/fits_schema/exceptions.py
+++ b/src/fits_schema/exceptions.py
@@ -40,6 +40,5 @@ class WrongValue(ValidationError):
 class AdditionalHeaderCard(UserWarning):
     """Issued when a header has a card not mentioned in the schema."""
 
-
 class SchemaError(ValueError):
     """Errors in Schema Definition, not data validation."""

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -327,6 +327,7 @@ def test_string_columns(tmp_path):
     from astropy.table import Table
 
     from fits_schema.binary_table import BinaryTable, String
+    from fits_schema.exceptions import WrongType
 
     class ExampleTable(BinaryTable):
         string = String()
@@ -341,3 +342,8 @@ def test_string_columns(tmp_path):
     # ensure that a string with units is rejected as a schema error.
     with pytest.raises(SchemaError):
         String(unit="TeV")
+
+    # ensure no non-ascii characters:
+    String().validate_data(np.array(["good", "also_good!?|"]))
+    with pytest.raises(WrongType):
+        String().validate_data(np.array(["good", "bâd"]))

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -335,8 +335,8 @@ def test_string_columns(tmp_path):
     test_table = Table(dict(string=["this", "test"]))
     test_table.write(outfile, format="fits", overwrite=True)
 
-    test_hdu = fits.open(outfile)[1]
-    ExampleTable.validate_hdu(test_hdu)
+    with fits.open(outfile) as fits_file:
+        ExampleTable.validate_hdu(fits_file[1])
 
     # ensure that a string with units is rejected as a schema error.
     with pytest.raises(SchemaError):

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -322,20 +322,22 @@ def test_column_name():
         Int32(name="Has Spaces")
 
 
-def test_string_columns():
+def test_string_columns(tmp_path):
     from astropy.io import fits
     from astropy.table import Table
 
-    from fits_schema.binary_table import BinaryTable, Column
+    from fits_schema.binary_table import BinaryTable, String
 
     class ExampleTable(BinaryTable):
-        name = Column(dtype=str)
-        value = Column(dtype=np.int64)
+        string = String()
 
-    test_table = Table(dict(value=[1, 2, 3, 4], name=["this", "is", "a", "test"]))
-    test_hdu = fits.BinTableHDU(data=test_table)
+    outfile = tmp_path / "test_string_col.fits"
+    test_table = Table(dict(string=["this", "test"]))
+    test_table.write(outfile, format="fits", overwrite=True)
+
+    test_hdu = fits.open(outfile)[1]
     ExampleTable.validate_hdu(test_hdu)
 
     # ensure that a string with units is rejected as a schema error.
     with pytest.raises(SchemaError):
-        Column(dtype=str, unit="TeV")
+        String(unit="TeV")

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -6,6 +6,7 @@ from astropy.table import Table
 
 from fits_schema.exceptions import (
     RequiredMissing,
+    SchemaError,
     WrongDims,
     WrongShape,
     WrongType,
@@ -334,3 +335,7 @@ def test_string_columns():
     test_table = Table(dict(value=[1, 2, 3, 4], name=["this", "is", "a", "test"]))
     test_hdu = fits.BinTableHDU(data=test_table)
     ExampleTable.validate_hdu(test_hdu)
+
+    # ensure that a string with units is rejected as a schema error.
+    with pytest.raises(SchemaError):
+        Column(dtype=str, unit="TeV")

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -319,3 +319,18 @@ def test_column_name():
 
     with pytest.warns(UserWarning):
         Int32(name="Has Spaces")
+
+
+def test_string_columns():
+    from astropy.io import fits
+    from astropy.table import Table
+
+    from fits_schema.binary_table import BinaryTable, Column
+
+    class ExampleTable(BinaryTable):
+        name = Column(dtype=str)
+        value = Column(dtype=np.int64)
+
+    test_table = Table(dict(value=[1, 2, 3, 4], name=["this", "is", "a", "test"]))
+    test_hdu = fits.BinTableHDU(data=test_table)
+    ExampleTable.validate_hdu(test_hdu)


### PR DESCRIPTION
This builds on #11 for now, and adds support for String columns, which are needed e.g. to support the [Hierarchical Grouping Convention](https://fits.gsfc.nasa.gov/registry/grouping/grouping.pdf).  

For columns with `dtype=str`, it ensures that the table data dtype is compatible with either the `U` or `S` dtype.