### PR TITLE
Support string columns with Char

### DIFF
--- a/src/fits_schema/__init__.py
+++ b/src/fits_schema/__init__.py
@@ -12,6 +12,7 @@ from .binary_table import (
     Int16,
     Int32,
     Int64,
+    String,
     Table,
 )
 from .header import Header, HeaderCard
@@ -33,5 +34,5 @@ __all__ = [
     "ComplexDouble",
     "Table",
     "BitField",
-    "Char",
+    "String",
 ]

--- a/src/fits_schema/__init__.py
+++ b/src/fits_schema/__init__.py
@@ -33,4 +33,5 @@ __all__ = [
     "ComplexDouble",
     "Table",
     "BitField",
+    "Char",
 ]

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -410,17 +410,26 @@ class String(Column):
         Parameters
         ----------
         string_size: int | None
-           require exact string storage size in characters
-           (termination character included).
+           required column element storage size in characters. Note that strings
+           may be smaller than this size if termination characters are used.
         max_string_length: int | None
-           require strings to be less than or equal to this number of characters
+           require strings to be less than or equal to this number of characters,
+           even if storage size is larger.
         min_string_length: int | None
-           require strings to be less than or equal to this number of characters
+           require strings to be longer than or equal to this number of characters
         """
         super().__init__(**kwargs)
         self.string_size = string_size
         self.max_string_length = max_string_length
         self.min_string_length = min_string_length
+
+        if string_size and (
+            max_string_length > string_size or min_string_length > string_size
+        ):
+            raise ValueError(
+                "Specified a max or min string length that is "
+                "incompatible with the required string size"
+            )
 
     def validate_data(self, data, onerror="raise"):
         """Validate the data of this column in table."""

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -174,12 +174,12 @@ class Column(metaclass=ABCMeta):
                 # always, however if you call hdu.data[column], they are
                 # magically converted to 'U' by astropy, but not for astropy
                 # Tables or np.recarrays (why is not obvious).
-                data = np.asanyarray(data).astype("U", casting="safe")
-
-                # string data must be ascii only:
-                if not all(s.isascii() for s in data.ravel()):
+                try:
+                    # string data must be ascii only, so ensure it by casting:
+                    data = np.asanyarray(data).astype("S")
+                except UnicodeError as err:
                     log_or_raise(
-                        f"Column '{self.name}': non-ascii data is not allowed ({data=})",
+                        f"Column '{self.name}': non-ascii data is not allowed ({data=}): {err}",
                         WrongType,
                         log=log,
                         onerror=onerror,

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -175,6 +175,15 @@ class Column(metaclass=ABCMeta):
                 # magically converted to 'U' by astropy, but not for astropy
                 # Tables or np.recarrays (why is not obvious).
                 data = np.asanyarray(data).astype("U", casting="safe")
+
+                # string data must be ascii only:
+                if not all(s.isascii() for s in data.ravel()):
+                    log_or_raise(
+                        f"Column '{self.name}': non-ascii data is not allowed ({data=})",
+                        WrongType,
+                        log=log,
+                        onerror=onerror,
+                    )
             else:
                 data = np.asanyarray(data).astype(self.dtype, casting="safe")
         except TypeError as e:

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -32,7 +32,7 @@ __all__ = [
     "Int16",
     "Int32",
     "Int64",
-    "Char",
+    "String",
     "Float",
     "Double",
     "ComplexFloat",
@@ -389,8 +389,8 @@ class Int64(Column):
     dtype = np.int64
 
 
-class Char(Column):
-    """Single byte character binary table column."""
+class String(Column):
+    """Character string binary table column."""
 
     tform_code = "A"
     dtype = np.dtype("S1")

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -153,7 +153,7 @@ class Column(metaclass=ABCMeta):
         if data is None:
             if self.required:
                 log_or_raise(
-                    f"Column {self.name} is required but missing",
+                    f"Column '{self.name}' is required but missing",
                     RequiredMissing,
                     log=log,
                     onerror=onerror,
@@ -179,7 +179,7 @@ class Column(metaclass=ABCMeta):
                 data = np.asanyarray(data).astype(self.dtype, casting="safe")
         except TypeError as e:
             log_or_raise(
-                f"dtype not convertible to column dtype: {e}",
+                f"Column '{self.name}': dtype not convertible to column dtype: {e}",
                 WrongType,
                 log=log,
                 onerror=onerror,
@@ -187,17 +187,17 @@ class Column(metaclass=ABCMeta):
 
         if self.strict_unit and hasattr(data, "unit") and data.unit != self.unit:
             log_or_raise(
-                f"Unit {data.unit} of data does not match specified unit {self.unit}",
+                f"Column '{self.name}': unit '{data.unit}' of data does not match specified unit '{self.unit}'",
                 WrongUnit,
                 log=log,
                 onerror=onerror,
             )
 
-        # a table as one dimension more than it's rows,
+        # a table has one dimension more than it's rows,
         # we also allow a single scalar value for scalar rows
         if data.ndim != self.ndim + 1 and not (data.ndim == 0 and self.ndim == 0):
             log_or_raise(
-                f"Dimensionality of rows is {data.ndim - 1}, should be {self.ndim}",
+                f"Column '{self.name}': dimensionality of rows is {data.ndim - 1}, should be {self.ndim}",
                 WrongDims,
                 log=log,
                 onerror=onerror,
@@ -211,12 +211,17 @@ class Column(metaclass=ABCMeta):
                 )
                 data = q
             except u.UnitConversionError as e:
-                log_or_raise(str(e), WrongUnit, log=log, onerror=onerror)
+                log_or_raise(
+                    "Column '{self.name}': " + str(e),
+                    WrongUnit,
+                    log=log,
+                    onerror=onerror,
+                )
 
         shape = data.shape[1:]
         if self.shape is not None and self.shape != shape:
             log_or_raise(
-                f"Shape {shape} does not match required shape {self.shape}",
+                f"Column '{self.name}': Shape {shape} does not match required shape {self.shape}",
                 WrongShape,
                 log=log,
                 onerror=onerror,

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -423,8 +423,11 @@ class String(Column):
         self.max_string_length = max_string_length
         self.min_string_length = min_string_length
 
-        if string_size and (
-            max_string_length > string_size or min_string_length > string_size
+        if (
+            (string_size and max_string_length)
+            and (max_string_length > string_size)
+            or (string_size and min_string_length)
+            and (min_string_length > string_size)
         ):
             raise ValueError(
                 "Specified a max or min string length that is "

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -404,3 +404,10 @@ def test_string_columns():
 
     # and also directly as a table
     TableWithStrings(table)
+
+    # check we can set the value using any type:
+    tab = TableWithStrings(table)
+    tab.string_col = np.asarray(["This", "is a", "string column"], dtype="S")
+    tab.string_col = np.asarray(["This", "is a", "string column"], dtype="U")
+    tab.string_col = np.asarray(["This", "is a", "string column"])
+    tab.string_col = ["This", "is a", "string column"]

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -364,23 +364,23 @@ def test_string_columns():
     from astropy.io import fits
     from astropy.table import Table
 
-    from fits_schema.binary_table import BinaryTable, BinaryTableHeader, Char
+    from fits_schema.binary_table import BinaryTable, BinaryTableHeader, String
 
     class TableWithStrings(BinaryTable):
         class __header__(BinaryTableHeader):
             pass
 
         # if shape not specified, should allow allb
-        string_col = Char()
+        string_col = String()
 
         # even for multi-dimensional string values:
-        nd_string_col = Char(ndim=1)
+        nd_string_col = String(ndim=1)
 
         # and finally ensure that if we do have a shape, it should be used:
-        shape_char_col = Char(shape=(2,))
+        shape_char_col = String(shape=(2,))
 
         # Make sure if a unicode string column is passed in, we don't fail
-        unicode_col = Char()
+        unicode_col = String()
 
     table = Table(
         {

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -351,3 +351,32 @@ def test_multiple_headers():
 
         class __header__(BinaryTableHeader, Headers1, Headers2):
             OBS_ID = HeaderCard(type_=int)
+
+
+def test_string_columns():
+    """Ensure we can use fixed (but unknown) length string columns.
+
+    Strings are just Char columns, but where we do not want to check for the
+    exact length, as the length is dependent on the longest string stored. If
+    shape=None, which is the default, this should work.
+    """
+    import numpy as np
+    from astropy.io import fits
+    from astropy.table import Table
+
+    from fits_schema.binary_table import BinaryTable, BinaryTableHeader, Char
+
+    class TableWithStrings(BinaryTable):
+        class __header__(BinaryTableHeader):
+            pass
+
+        string_col = Char(shape=None)  # if shape not specified, should allow all
+
+    table = Table(
+        {
+            "string_col": np.asarray(["This", "is", "a", "string column"], dtype="S"),
+        }
+    )
+    hdu = fits.BinTableHDU(data=table)
+
+    TableWithStrings.validate_hdu(hdu)

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -371,10 +371,17 @@ def test_string_columns():
             pass
 
         string_col = Char(shape=None)  # if shape not specified, should allow all
+        nd_string_col = Char(
+            ndim=1, shape=None
+        )  # if shape not specified, should allow all
 
     table = Table(
         {
-            "string_col": np.asarray(["This", "is", "a", "string column"], dtype="S"),
+            "string_col": np.asarray(["This", "is a", "string column"], dtype="S"),
+            "nd_string_col": np.asarray(
+                [["This", "is"], ["an", "n-dim string"], ["string", "column"]],
+                dtype="S",
+            ),
         }
     )
     hdu = fits.BinTableHDU(data=table)

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -388,6 +388,9 @@ def test_string_columns():
         # column with a maximum string length of 10 characters
         min_col = String(min_string_length=4)
 
+        # column requiring fixed size storage of 7 characters
+        fixed_size = String(string_size=7)
+
     table = Table(
         {
             "string_col": np.asarray(["This", "is a", "string column"], dtype="S"),
@@ -402,6 +405,7 @@ def test_string_columns():
             "unicode_col": np.asarray(["This", "is a", "string column"], dtype="U"),
             "max_col": np.asarray(["short", "strings", "are ok"], dtype="S"),
             "min_col": np.asarray(["must", "be at least", "4 chars"], dtype="S"),
+            "fixed_size": np.asarray(["test", "test2", "test3"]).astype("S7"),
         }
     )
 
@@ -441,5 +445,10 @@ def test_string_columns():
 
     tab = TableWithStrings(table)
     tab.min_col = ["This is ok", "not", "ok"]
+    with pytest.raises(WrongShape):
+        tab.validate_data()
+
+    tab = TableWithStrings(table)
+    tab.fixed_size = np.array(["This is ok", "not", "ok"]).astype("S20")
     with pytest.raises(WrongShape):
         tab.validate_data()

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -370,10 +370,14 @@ def test_string_columns():
         class __header__(BinaryTableHeader):
             pass
 
-        string_col = Char(shape=None)  # if shape not specified, should allow all
-        nd_string_col = Char(
-            ndim=1, shape=None
-        )  # if shape not specified, should allow all
+        # if shape not specified, should allow allb
+        string_col = Char()
+
+        # even for multi-dimensional string values:
+        nd_string_col = Char(ndim=1)
+
+        # and finally ensure that if we do have a shape, it should be used:
+        shape_char_col = Char(shape=(2,))
 
     table = Table(
         {
@@ -382,8 +386,13 @@ def test_string_columns():
                 [["This", "is"], ["an", "n-dim string"], ["string", "column"]],
                 dtype="S",
             ),
+            "shape_char_col": np.asarray(
+                [["This", "is"], ["an", "n-dim string"], ["string", "column"]],
+                dtype="S",
+            ),
         }
     )
+
     hdu = fits.BinTableHDU(data=table)
 
     TableWithStrings.validate_hdu(hdu)

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -382,6 +382,12 @@ def test_string_columns():
         # Make sure if a unicode string column is passed in, we don't fail
         unicode_col = String()
 
+        # column with a maximum string length of 10 characters
+        max_col = String(max_string_length=10)
+
+        # column with a maximum string length of 10 characters
+        min_col = String(min_string_length=4)
+
     table = Table(
         {
             "string_col": np.asarray(["This", "is a", "string column"], dtype="S"),
@@ -394,6 +400,8 @@ def test_string_columns():
                 dtype="S",
             ),
             "unicode_col": np.asarray(["This", "is a", "string column"], dtype="U"),
+            "max_col": np.asarray(["short", "strings", "are ok"], dtype="S"),
+            "min_col": np.asarray(["must", "be at least", "4 chars"], dtype="S"),
         }
     )
 
@@ -417,6 +425,21 @@ def test_string_columns():
     tab.validate_data()
 
     # check that non-ascii is forbidden:
+    tab = TableWithStrings(table)
     tab.string_col = ["This", "is a", "bad å¬≠≈ç´"]
     with pytest.raises(WrongType):
+        tab.validate_data()
+
+    tab = TableWithStrings(table)
+    tab.max_col = [
+        "This is far too long",
+        "a string",
+        "that should be under 10 chars",
+    ]
+    with pytest.raises(WrongShape):
+        tab.validate_data()
+
+    tab = TableWithStrings(table)
+    tab.min_col = ["This is ok", "not", "ok"]
+    with pytest.raises(WrongShape):
         tab.validate_data()

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -408,6 +408,15 @@ def test_string_columns():
     # check we can set the value using any type:
     tab = TableWithStrings(table)
     tab.string_col = np.asarray(["This", "is a", "string column"], dtype="S")
+    tab.validate_data()
     tab.string_col = np.asarray(["This", "is a", "string column"], dtype="U")
+    tab.validate_data()
     tab.string_col = np.asarray(["This", "is a", "string column"])
+    tab.validate_data()
     tab.string_col = ["This", "is a", "string column"]
+    tab.validate_data()
+
+    # check that non-ascii is forbidden:
+    tab.string_col = ["This", "is a", "bad å¬≠≈ç´"]
+    with pytest.raises(WrongType):
+        tab.validate_data()

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -379,6 +379,9 @@ def test_string_columns():
         # and finally ensure that if we do have a shape, it should be used:
         shape_char_col = Char(shape=(2,))
 
+        # Make sure if a unicode string column is passed in, we don't fail
+        unicode_col = Char()
+
     table = Table(
         {
             "string_col": np.asarray(["This", "is a", "string column"], dtype="S"),
@@ -390,9 +393,14 @@ def test_string_columns():
                 [["This", "is"], ["an", "n-dim string"], ["string", "column"]],
                 dtype="S",
             ),
+            "unicode_col": np.asarray(["This", "is a", "string column"], dtype="U"),
         }
     )
 
     hdu = fits.BinTableHDU(data=table)
 
+    # try via HDU conversion first:
     TableWithStrings.validate_hdu(hdu)
+
+    # and also directly as a table
+    TableWithStrings(table)


### PR DESCRIPTION
Changes dtype check  in `Column` to look only for the base dtype in the case of columns with numpy dtypes 'S' or 'U'. 

Oddly, _astropy.io.fits_ seems to do some type conversion when accessing a column of a `FITS_rec`, so this should work with `HDUs`, but perhaps not with bare numpy `recarrays` or astropy `tables`, which do not convert 'S' to 'U' on column access.  @maxnoe what is the assumption here: do we always expect that the checks are done on proper HDU objects, and not passed in (or set) as recarrays?

Also changes slightly the logic of the unit check, to only check if a unit was specified, since string columns are not convertable to unit quantities.

