### PR TITLE
Add ability to output schema in FITS tpl format 

### DIFF
--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -196,12 +196,12 @@ class Column(SchemaElement, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def dtype() -> type:
+    def dtype(self) -> type:
         """Equivalent numpy dtype."""
 
     @property
     @abstractmethod
-    def tform_code() -> str:
+    def tform_code(self) -> str:
         """FITS Format code."""
 
     def validate_data(self, data, onerror="raise"):

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -48,23 +48,16 @@ _string_length = np.vectorize(len)
 
 FORTRAN_FORMAT_REGEX = re.compile(
     r"""
-    \s*                    # Optional spaces
-    (\d+)?                 # Optional repeat count
-    (                      # Group for format descriptors
-        I\d+               | # Integer format
-        F\d+\.\d+          | # Floating point format
-        E\d+\.\d+          | # Scientific notation format
-        D\d+\.\d+          | # Double precision scientific format
-        A\d+               | # String format
-        L\d+               | # Logical format
-        X\d+               | # Space format
-        G\d+\.\d+          | # General format
-        T\d+               | # Tab format
-        '(.*?)'            | # Literal string format
-    )
-    \s*                    # Optional spaces
+    ^(
+        A\d+ |                                  # Character: Aw (A followed by digits)
+        [IBOZ]\d+(\.\d+)? |                     # Integer: Iw[.m], Binary/Octal/Hex: Bw[.m], Ow[.m], Zw[.m]
+        F\d+\.\d+ |                             # Fixed-point: Fw.d
+        (E|D|G)\d+\.\d+(E\d+)? |                # Exponential/General: Ew.d[Ee], Dw.d[Ee], Gw.d[Ee]
+        EN\d+\.\d+ |                            # Engineering: ENw.d
+        ES\d+\.\d+                              # Scientific: ESw.d
+    )$
 """,
-    re.VERBOSE | re.IGNORECASE,
+    re.VERBOSE,
 )
 
 
@@ -138,8 +131,8 @@ class Column(SchemaElement, metaclass=ABCMeta):
         self.ndim = ndim
         self.display_format = display_format
 
-        if self.display_format and not re.match(
-            FORTRAN_FORMAT_REGEX, self.display_format
+        if self.display_format and not FORTRAN_FORMAT_REGEX.fullmatch(
+            self.display_format
         ):
             raise SchemaError(
                 f"Column {self.name}: display format '{self.display_format}'"

--- a/src/fits_schema/binary_table.py
+++ b/src/fits_schema/binary_table.py
@@ -64,19 +64,21 @@ class Column(SchemaElement, metaclass=ABCMeta):
 
     Attributes
     ----------
-    unit: astropy.units.Unit
+    unit: astropy.units.Unit | None
         unit of the column
     strict_unit: bool
         If True, the unit must match exactly, not only be convertible.
     required: bool
         If this column is required (True) or optional (False)
-    name: str
+    name: str | None
         Use to specify a different column name than the class attribute name.
-    ndim: int
+    ndim: int | None
         Dimensionality of a single row, numbers have ndim=0.
         The resulting data column has ``ndim_col = ndim + 1``
-    shape: Tuple[int]
+    shape: tuple[int] | None
         Shape of a single row.
+    format: str | None
+        Fortran-style text format string (TFORM#) for converting values to strings.
     """
 
     def __init__(
@@ -84,8 +86,9 @@ class Column(SchemaElement, metaclass=ABCMeta):
         *,
         strict_unit=False,
         name=None,
-        ndim=None,
-        shape=None,
+        ndim: int | None = None,
+        shape: tuple[int] | None = None,
+        format: str | None = None,
         description: str = "",
         required: bool = True,
         unit: u.Unit | None = None,
@@ -108,6 +111,7 @@ class Column(SchemaElement, metaclass=ABCMeta):
         self.name = name
         self.shape = shape
         self.ndim = ndim
+        self.format = format
 
         if self.shape is not None:
             self.shape = tuple(shape)
@@ -159,8 +163,13 @@ class Column(SchemaElement, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def dtype():
+    def dtype() -> type:
         """Equivalent numpy dtype."""
+
+    @property
+    @abstractmethod
+    def tform_code() -> str:
+        """FITS Format code."""
 
     def validate_data(self, data, onerror="raise"):
         """Validate the data of this column in table."""

--- a/src/fits_schema/output_template.py
+++ b/src/fits_schema/output_template.py
@@ -105,8 +105,8 @@ def column_template(column: Column) -> Generator[str]:
         yield f"TUCD#  = {column.ucd:20s}"
     if column.ndim:
         yield f"TDIM#  = {column.ndim:<20d} / value is a {column.ndim}-dimensional array"
-    # if column.format:
-    #     yield f"TDISP#  = {column.format:20s} / display format"
+    if column.display_format:
+        yield f"TDISP#  = {column.display_format:20s} / display format (FORTRAN-style)"
     yield ""  # spacer
 
 

--- a/src/fits_schema/output_template.py
+++ b/src/fits_schema/output_template.py
@@ -115,12 +115,13 @@ def bintable_template(hdu: BinaryTable) -> Generator[str]:
     yield DOUBLE_LINE
     yield f"/ HDU: {hdu.__name__}"  # should put in the EXTNAME here...
     yield "/ DESCRIPTION: "
-    yield from wrap(
-        hdu.__doc__,
-        initial_indent="/    ",
-        subsequent_indent="/    ",
-        drop_whitespace=True,
-    )
+    if hdu.__doc__:
+        yield from wrap(
+            hdu.__doc__,
+            initial_indent="/    ",
+            subsequent_indent="/    ",
+            drop_whitespace=True,
+        )
 
     yield SINGLE_LINE
     yield "/ HEADERS: "
@@ -129,7 +130,7 @@ def bintable_template(hdu: BinaryTable) -> Generator[str]:
 
     # output the headers, but no the BinaryTableHeaders ones, which we want to
     # treat specially
-    yield from header_template(hdu.__header__)  # exclude=[BinaryTableHeader])
+    yield from header_template(hdu.__header__)
 
     yield SINGLE_LINE
     yield "/ COLUMNS: "

--- a/src/fits_schema/output_template.py
+++ b/src/fits_schema/output_template.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+"""Code to convert fits schemas into FITS TPL files.
+
+This is mainly a test of introspection and documentation, but can be helpful for
+use in fits tools that can read the TPL format.
+"""
+
+from collections.abc import Generator, Iterable
+from textwrap import wrap
+
+from astropy import units as u
+
+from .binary_table import BinaryTable, Column
+from .header import Header, HeaderCard
+from .schema_element import SchemaElement
+
+SINGLE_LINE = "".join(["/ ", "-" * 87])
+DOUBLE_LINE = "".join(["/ ", "=" * 87])
+
+
+def unit_str(element: SchemaElement):
+    """Convert unit to comment string."""
+    if not element.unit:
+        return ""
+    return f"[{u.Unit(element.unit.to_string('fits'))}] "
+
+
+def type_str(element: SchemaElement):
+    """Convert type to comment string."""
+    # Note this will be much simpler when we have a proper type class hierarchy
+    if not element.type:
+        return ""
+
+    # WHy not just make all type values to be tuples? Having to support both
+    # scalar and tuple is annoying.
+    if isinstance(element.type, Iterable):
+        return f"({','.join(x.__name__ for x in element.type)}) "
+    else:
+        return f"({element.type.__name__}) "
+
+
+def header_card_template(card: HeaderCard) -> Generator[str]:
+    """Output FITS template lines for a HeaderCard."""
+    optional = " optional " if card.required is False else ""
+    value = card.allowed_values.copy().pop() if card.allowed_values else ""
+
+    yield f"{card.keyword.upper():8s} = {value:<10} / {unit_str(card)}{optional}{type_str(card)}{card.description}"
+
+
+def header_template(
+    header: Header, exclude: set[Header] | None = None
+) -> Generator[str]:
+    """Output FITS template lines for a Header.
+
+    Parameters
+    ----------
+    exclude : set[Header] | None
+        header groups to exclude from the template
+    """
+    if exclude:
+        exclude = set(exclude)
+    else:
+        exclude = set()
+
+    for group, cards in header.grouped_cards().items():
+        if group in exclude or len(cards) == 0:
+            continue
+
+        group_name = group.__name__
+        if group_name == "__header__":
+            group_name = "Headers specific to this HDU"
+
+        if group.__doc__:
+            yield from wrap(
+                f"{group_name}: {group.__doc__}",
+                initial_indent="/    ",
+                subsequent_indent="/    ",
+                drop_whitespace=True,
+            )
+        else:
+            yield f"/    {group_name}:"
+
+        for card in cards.values():
+            yield from header_card_template(card)
+
+        yield ""
+
+
+def column_template(column: Column) -> Generator[str]:
+    """Output FITS template lines for a Column."""
+    yield f"TTYPE# = {column.name:20s} / {column.description:.70s}"
+
+    if not hasattr(column, "tform_code"):
+        raise AttributeError(f"Missing tform_code for column {column}")
+
+    yield f"TFORM# = {column.tform_code:20s} / {column.dtype.__name__}"
+
+    if column.unit:
+        yield (
+            f"TUNIT# = {u.Unit(column.unit).to_string('fits'):20s}"
+            f" / or convertible to '{u.Unit(column.unit).physical_type}'"
+        )
+    if column.ucd:
+        yield f"TUCD#  = {column.ucd:20s}"
+    if column.ndim:
+        yield f"TDIM#  = {column.ndim:<20d} / value is a {column.ndim}-dimensional array"
+    # if column.format:
+    #     yield f"TDISP#  = {column.format:20s} / display format"
+    yield ""  # spacer
+
+
+def bintable_template(hdu: BinaryTable) -> Generator[str]:
+    """Output FITS template lines for a full HDU."""
+    yield DOUBLE_LINE
+    yield f"/ HDU: {hdu.__name__}"  # should put in the EXTNAME here...
+    yield "/ DESCRIPTION: "
+    yield from wrap(
+        hdu.__doc__,
+        initial_indent="/    ",
+        subsequent_indent="/    ",
+        drop_whitespace=True,
+    )
+
+    yield SINGLE_LINE
+    yield "/ HEADERS: "
+    yield SINGLE_LINE
+    yield ""
+
+    # output the headers, but no the BinaryTableHeaders ones, which we want to
+    # treat specially
+    yield from header_template(hdu.__header__)  # exclude=[BinaryTableHeader])
+
+    yield SINGLE_LINE
+    yield "/ COLUMNS: "
+    yield SINGLE_LINE
+    yield ""
+
+    for column in hdu.__columns__.values():
+        yield from column_template(column)
+
+    yield "END"

--- a/src/fits_schema/output_template.py
+++ b/src/fits_schema/output_template.py
@@ -106,7 +106,7 @@ def column_template(column: Column) -> Generator[str]:
     if column.ndim:
         yield f"TDIM#  = {column.ndim:<20d} / value is a {column.ndim}-dimensional array"
     if column.display_format:
-        yield f"TDISP#  = {column.display_format:20s} / display format (FORTRAN-style)"
+        yield f"TDISP# = {column.display_format:20s} / display format (FORTRAN-style)"
     yield ""  # spacer
 
 

--- a/src/fits_schema/output_template.py
+++ b/src/fits_schema/output_template.py
@@ -32,7 +32,7 @@ def type_str(element: SchemaElement):
     if not element.type:
         return ""
 
-    # WHy not just make all type values to be tuples? Having to support both
+    # TODO: Why not just make all type values to be tuples? Having to support both
     # scalar and tuple is annoying.
     if isinstance(element.type, Iterable):
         return f"({','.join(x.__name__ for x in element.type)}) "

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -6,6 +6,7 @@ from astropy.table import Column, Table
 
 from fits_schema.exceptions import (
     RequiredMissing,
+    SchemaError,
     WrongDims,
     WrongShape,
     WrongType,
@@ -455,7 +456,27 @@ def test_string_columns():
 
 
 def test_column_format():
-    from fits_schema.binary_table import Int64
+    from fits_schema.binary_table import FORTRAN_FORMAT_REGEX, Int64
 
-    col = Int64(name="test", display_format="2F8.2")
+    col = Int64(name="test", display_format="F8.2")
     assert col
+
+    test_values = [
+        "A10",
+        "I5",
+        "B8.3",
+        "O10",
+        "Z16",  # Character and integer formats
+        "F10.5",
+        "E12.3E2",
+        "D8.2E1",
+        "G15.4E3",  # Floating-point formats
+        "EN10.3",
+        "ES8.2",  # Engineering and scientific formats
+    ]
+
+    for value in test_values:
+        assert FORTRAN_FORMAT_REGEX.fullmatch(value)
+
+    with pytest.raises(SchemaError):
+        col = Int64(name="test", display_format="blarg")

--- a/src/fits_schema/tests/test_binary_table.py
+++ b/src/fits_schema/tests/test_binary_table.py
@@ -452,3 +452,10 @@ def test_string_columns():
     tab.fixed_size = np.array(["This is ok", "not", "ok"]).astype("S20")
     with pytest.raises(WrongShape):
         tab.validate_data()
+
+
+def test_column_format():
+    from fits_schema.binary_table import Int64
+
+    col = Int64(name="test", display_format="2F8.2")
+    assert col

--- a/src/fits_schema/tests/test_header.py
+++ b/src/fits_schema/tests/test_header.py
@@ -203,6 +203,7 @@ def test_grouped_headers():
         """Group 1."""
 
         KEY1 = HeaderCard()
+        OVERRIDE = HeaderCard()
 
     class Group2(Header):
         """Group 2."""
@@ -213,12 +214,16 @@ def test_grouped_headers():
         """Compound."""
 
         COMPKEY = HeaderCard()
+        OVERRIDE = HeaderCard(allowed_values="overridden", unit="m")
 
     grouped = CompoundHeader.grouped_cards()
 
     assert "KEY1" in grouped[Group1]
     assert "KEY2" in grouped[Group2]
     assert "COMPKEY" in grouped[CompoundHeader]
+
+    # ensure inheritance works in the groups
+    assert grouped[CompoundHeader]["OVERRIDE"].unit is not None
 
 
 def test_unknown_keyword():

--- a/src/fits_schema/tests/test_output_template.py
+++ b/src/fits_schema/tests/test_output_template.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+"""Check output to FITS templates."""
+
+
+def test_output_hdu():
+    """Checks BinTable, Header, HeaderCard, and Column outputs."""
+
+    from fits_schema import BinaryTable, BinaryTableHeader, Double, HeaderCard, Int64
+    from fits_schema.output_template import bintable_template
+
+    class TestTable(BinaryTable):
+        """An example binary table."""
+
+        class __header__(BinaryTableHeader):
+            EXTNAME = HeaderCard(allowed_values="TEST_EXT")
+            EXTRA = HeaderCard(description="Extra info, not in the base class")
+
+        ENERGY = Double(
+            unit="TeV",
+            description="Estimated Energy",
+            ucd="em.energy",
+            display_format="F5.2",
+        )
+        EVENT_ID = Int64(description="Event identifier, unique within an observation")
+
+    template_lines = list(bintable_template(TestTable))
+
+    assert len(template_lines) > 10


### PR DESCRIPTION
Features added:
* output_template.py: functions to output FITS TPL-style schemas
* added missing `display_format` metadata to Column (maps to TDISPn headers)
* fixed a bug in `Header.grouped_cards()` where inheritance was not perserved


THe main feature is now if you have any part of a schema, like an HDU, you can call a function to generate a FITS template from it. This is mostly as a test to see if all metadata are sufficient to generate documentation, but can also be useful to get an overview of a schema.

Example:
```py3
from fits_schema.output_template import bintable_template

print("\n".join(bintable_template(TestTable)))
```
```
/ =======================================================================================
/ HDU: TestTable
/ DESCRIPTION: 
/    An example binary table.
/ ---------------------------------------------------------------------------------------
/ HEADERS: 
/ ---------------------------------------------------------------------------------------

/    Headers specific to this HDU:
EXTNAME  = TEST_EXT   / (str) 
EXTRA    =            / Extra info, not in the base class

/    BinaryTableHeader: Default binary table header schema.
XTENSION = BINTABLE   / (str) 
BITPIX   = 8          / (int) 
NAXIS    = 2          / (int) 
NAXIS1   =            / (int) 
NAXIS2   =            / (int) 
PCOUNT   =            / (int) 
GCOUNT   = 1          / (int) 
TFIELDS  =            / (int) 

/    TestHeaders:
TEST     =            / 

/    CoordinateSystem: Coordinate system definition.
EQUINOX  = 2000.0     / [yr]  optional (float) Coordinate epoch. Optional since implied by RADECSYS
RADECSYS = ICRS       / (str) Coordinate stellar reference frame

/    DataProductHeaders: Identify this HDU.
DATE     =            / (str) Date of HDU creation

/    TimeDefinition: Header keywords for the definition of time
/    columns.
MJDREFI  =            / (int) 
MJDREFF  =            / (float) 
TIMEUNIT = S          / (str) 
TIMESYS  = TAI        / (str) 
TIMEREF  = SOLARSYSTEM / (str) 

/    ReferencePosition: Reference position of the observatory, for
/    time and coordinates.  This version of VODF supports only Earth-
/    centered locations.
TREFPOS  = TOPOCENTER / (str) Code for the spatial location at which the observation time is valid
OBSGEO-B =            / [deg] (float) the latitude of the observation, with North positive
OBSGEO-L =            / [deg] (float) the longitide of the observation, with East positive
OBSGEO-H =            / [m] (float) the altitude of the observation

/ ---------------------------------------------------------------------------------------
/ COLUMNS: 
/ ---------------------------------------------------------------------------------------

TTYPE# = ENERGY               / Estimated Energy
TFORM# = D                    / float64
TUNIT# = TeV                  / or convertable to 'energy/torque/work'
TUCD#  = em.energy           
TDISP# = F8.2                 / display format (FORTRAN-style)

TTYPE# = EVENT_ID             / Event identifier, unique within an observation
TFORM# = K                    / int64

END
```