### PR TITLE
fix TFORM printout bug

### DIFF
--- a/src/fits_schema/output_template.py
+++ b/src/fits_schema/output_template.py
@@ -94,7 +94,7 @@ def column_template(column: Column) -> Generator[str]:
     if not hasattr(column, "tform_code"):
         raise AttributeError(f"Missing tform_code for column {column}")
 
-    yield f"TFORM# = {column.tform_code:20s} / {column.dtype.__name__}"
+    yield f"TFORM# = {column.tform_code:20s} / {column.__class__.__name__}"
 
     if column.unit:
         yield (

--- a/src/fits_schema/tests/test_output_template.py
+++ b/src/fits_schema/tests/test_output_template.py
@@ -6,7 +6,14 @@
 def test_output_hdu():
     """Checks BinTable, Header, HeaderCard, and Column outputs."""
 
-    from fits_schema import BinaryTable, BinaryTableHeader, Double, HeaderCard, Int64
+    from fits_schema import (
+        BinaryTable,
+        BinaryTableHeader,
+        Double,
+        HeaderCard,
+        Int64,
+        String,
+    )
     from fits_schema.output_template import bintable_template
 
     class TestTable(BinaryTable):
@@ -23,6 +30,7 @@ def test_output_hdu():
             display_format="F5.2",
         )
         EVENT_ID = Int64(description="Event identifier, unique within an observation")
+        STRING_COL = String()
 
     template_lines = list(bintable_template(TestTable))
 


### PR DESCRIPTION
Use the column class name, not the dtype name since the latter doesn't always have a `__name__` attribute.

Fixes #40